### PR TITLE
chore(release): pulling release/1.0.4 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### 1.0.4 (2023-02-16)
+
+
+### Bug Fixes
+
+* handle brand property in products ([b217f7e](https://github.com/rudderlabs/rudder-integration-clevertap-ios/commit/b217f7e7503a5c257a98c33b5231a435ec901671))

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - CleverTap-iOS-SDK (3.10.0):
     - SDWebImage (~> 5.1)
-  - Rudder (1.1.3)
-  - Rudder-CleverTap (1.0.1):
-    - CleverTap-iOS-SDK
-    - Rudder
-  - SDWebImage (5.12.1):
-    - SDWebImage/Core (= 5.12.1)
-  - SDWebImage/Core (5.12.1)
+  - Rudder (1.10.0)
+  - Rudder-CleverTap (1.0.3):
+    - CleverTap-iOS-SDK (~> 3.0)
+    - Rudder (~> 1.0)
+  - SDWebImage (5.15.2):
+    - SDWebImage/Core (= 5.15.2)
+  - SDWebImage/Core (5.15.2)
 
 DEPENDENCIES:
   - Rudder-CleverTap (from `../`)
@@ -24,10 +24,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CleverTap-iOS-SDK: 1e38a25eee5bdb3e525c5c8497504bc64b7d695d
-  Rudder: 4121e7e96f7c9bb975d0aa97da204b9d71fafdeb
-  Rudder-CleverTap: 7c887be621f8c3c1d9fac87db34836be8ca03764
-  SDWebImage: 4dc3e42d9ec0c1028b960a33ac6b637bb432207b
+  Rudder: 779dce4fdb93f3d102a876e13f5450074a4211e1
+  Rudder-CleverTap: f1429a62c26b6db1d4b0c7ea50b7bd8f907625e5
+  SDWebImage: 8ab87d4b3e5cc4927bd47f78db6ceb0b94442577
 
 PODFILE CHECKSUM: 5bdc8bea45680c7529abadb38ab094bd0dc5ae26
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/Rudder-CleverTap/Classes/RudderCleverTapIntegration.m
+++ b/Rudder-CleverTap/Classes/RudderCleverTapIntegration.m
@@ -326,6 +326,10 @@
         {
             transformedProduct[@"image_url"] = product[@"image_url"];
         }
+        if(product[@"brand"])
+        {
+            transformedProduct[@"brand"] = product[@"brand"];
+        }
         [transformedProducts addObject:transformedProduct];
     }
     return transformedProducts;

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
:crown: *An automated PR*

   <small>1.0.3 (2023-02-16)</small><br> * fix: handle brand property in products ([b217f7e](https://github.com/rudderlabs/rudder-integration-clevertap-ios/commit/b217f7e))<br> * ci: fix publish-new-release ([ca20e70](https://github.com/rudderlabs/rudder-integration-clevertap-ios/commit/ca20e70))